### PR TITLE
hy2内核双栈监听

### DIFF
--- a/core/hy2/config.go
+++ b/core/hy2/config.go
@@ -424,8 +424,11 @@ func extractPortFromAddr(addr string) int {
 }
 
 func formatAddress(ip string, port int) string {
-	if strings.Contains(ip, ":") {
-		return fmt.Sprintf("[%s]:%d", ip, port)
-	}
-	return fmt.Sprintf("%s:%d", ip, port)
+    if ip == "" { 
+        return fmt.Sprintf(":%d", port)
+    }
+    if strings.Contains(ip, ":") { 
+        return fmt.Sprintf("[%s]:%d", ip, port)
+    }
+    return fmt.Sprintf("%s:%d", ip, port) ]
 }


### PR DESCRIPTION
"ListenIP": ""  设置为空支持v6和v4，只限于hy2内核