### PR TITLE
fix: adjust rate limiting to use actual bytes transferred

### DIFF
--- a/common/rate/conn.go
+++ b/common/rate/conn.go
@@ -19,13 +19,19 @@ type Conn struct {
 }
 
 func (c *Conn) Read(b []byte) (n int, err error) {
-	c.limiter.Wait(int64(len(b)))
-	return c.Conn.Read(b)
+	n, err = c.Conn.Read(b)
+	if n > 0 {
+		c.limiter.Wait(int64(n))
+	}
+	return n, err
 }
 
 func (c *Conn) Write(b []byte) (n int, err error) {
-	c.limiter.Wait(int64(len(b)))
-	return c.Conn.Write(b)
+	n, err = c.Conn.Write(b)
+	if n > 0 {
+		c.limiter.Wait(int64(n))
+	}
+	return n, err
 }
 
 /*


### PR DESCRIPTION
必须“先读后等” 处理流控数据


fixes: #66 