### PR TITLE
增加docker支持,支持初始化配置

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,16 @@ RUN GOEXPERIMENT=jsonv2 go mod download
 RUN GOEXPERIMENT=jsonv2 go build -v -o V2bX -tags "sing xray hysteria2 with_quic with_grpc with_utls with_wireguard with_acme with_gvisor"
 
 # Release
-FROM  alpine
-# 安装必要的工具包
-RUN  apk --update --no-cache add tzdata ca-certificates \
+FROM alpine
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
+    && apk --no-cache add tzdata ca-certificates bash curl iproute2 \
     && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN mkdir /etc/V2bX/
-COPY --from=builder /app/V2bX /usr/local/bin
+COPY --from=builder /app/V2bX /usr/local/bin/V2bX
+RUN curl -fsSL https://raw.githubusercontent.com/wyx2685/V2bX-script/master/initconfig.sh \
+    -o /usr/local/lib/initconfig.sh
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-ENTRYPOINT [ "V2bX", "server", "--config", "/etc/V2bX/config.json"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ A V2board node server based on multi core, modified from XrayR.
 wget -N https://raw.githubusercontent.com/wyx2685/V2bX-script/master/install.sh && bash install.sh
 ```
 
+### Docker构建
+
+```bash
+# 拉取项目
+git clone https://github.com/wyx2685/V2bX.git && cd V2bX
+# 构建镜像
+docker build -t v2bx:latest .
+# 生成配置文件
+docker run -it --rm -v ./config:/etc/V2bX v2bx:latest generate
+# 启动容器
+docker compose up -d 
+```
+
 ### 手动安装
 
 [手动安装教程](https://v2bx.v-50.me/v2bx/v2bx-xia-zai-he-an-zhuang/install/manual)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   v2bx:
-    image: xusenhao/v2bx:latest
+    image: v2bx:latest
     restart: unless-stopped
     network_mode: host
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  v2bx:
+    image: xusenhao/v2bx:latest
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./config:/etc/V2bX

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+red='\033[0;31m'
+green='\033[0;32m'
+yellow='\033[0;33m'
+plain='\033[0m'
+
+if [ "$1" = "generate" ]; then
+    touch /etc/V2bX/config.json
+    v2bx() { echo -e "${green}配置文件已生成到 /etc/V2bX/${plain}"; }
+    export -f v2bx
+    source /usr/local/lib/initconfig.sh
+    generate_config_file
+else
+    exec V2bX server --config /etc/V2bX/config.json
+fi


### PR DESCRIPTION
### Quick Start
```bash
root@debian:~/V2bX# docker build -t v2bx:latest .
[+] Building 234.6s (20/20) FINISHED                                                                                                        docker:default
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 925B                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                      2.5s
 => [internal] load metadata for docker.io/library/golang:1.25.0-alpine                                                                               2.5s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                         0.0s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                       0.0s
 => [builder 1/5] FROM docker.io/library/golang:1.25.0-alpine@sha256:f18a072054848d87a8077455f0ac8a25886f2397f88bfdd222d6fafbb5bba440                 0.0s
 => [internal] load build context                                                                                                                     0.0s
 => => transferring context: 7.93kB                                                                                                                   0.0s
 => [stage-1 1/7] FROM docker.io/library/alpine:latest@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659                        0.0s
 => CACHED [builder 2/5] WORKDIR /app                                                                                                                 0.0s
 => [builder 3/5] COPY . .                                                                                                                            0.1s
 => [builder 4/5] RUN GOEXPERIMENT=jsonv2 go mod download                                                                                           171.7s
 => [builder 5/5] RUN GOEXPERIMENT=jsonv2 go build -v -o V2bX -tags "sing xray hysteria2 with_quic with_grpc with_utls with_wireguard with_acme wit  59.7s
 => CACHED [stage-1 2/7] RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories     && apk --no-cache add tzdata ca-certif  0.0s 
 => CACHED [stage-1 3/7] RUN mkdir /etc/V2bX/                                                                                                         0.0s 
 => CACHED [stage-1 4/7] COPY --from=builder /app/V2bX /usr/local/bin/V2bX                                                                            0.0s 
 => CACHED [stage-1 5/7] RUN curl -fsSL https://raw.githubusercontent.com/wyx2685/V2bX-script/master/initconfig.sh     -o /usr/local/lib/initconfig.  0.0s 
 => [stage-1 6/7] COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh                                                                       0.0s 
 => [stage-1 7/7] RUN chmod +x /usr/local/bin/docker-entrypoint.sh                                                                                    0.4s 
 => exporting to image                                                                                                                                0.0s
 => => exporting layers                                                                                                                               0.0s
 => => writing image sha256:c788832689a2e6e4dec8bf3e172d3e3993948e52ed5660370d9398cbedd7544b                                                          0.0s
 => => naming to docker.io/library/v2bx:latest                                                                                                        0.0s
root@debian:~/V2bX# docker run -it --rm -v ./config:/etc/V2bX v2bx:latest generate
V2bX 配置文件生成向导
请阅读以下注意事项：
1. 目前该功能正处测试阶段
2. 生成的配置文件会保存到 /etc/V2bX/config.json
3. 原来的配置文件会保存到 /etc/V2bX/config.json.bak
4. 目前仅部分支持TLS
5. 使用此功能生成的配置文件会自带审计，确定继续？(y/n)
请输入：y
请输入机场网址(https://example.com)：y
请输入面板对接API Key：y
是否设置固定的机场网址和API Key？(y/n)y
成功固定地址
请选择节点核心类型：
1. xray
2. singbox
3. hysteria2
请输入：2
请输入节点Node ID：2
请选择节点传输协议：
1. Shadowsocks
2. Vless
3. Vmess
4. Hysteria
5. Hysteria2
6. Trojan
7. Tuic
8. AnyTLS
请输入：2
请选择是否为reality节点？(y/n)n
是否继续添加节点配置？(回车继续，输入n或no退出)n
V2bX 配置文件生成完成,正在重新启动服务
配置文件已生成到 /etc/V2bX/

```